### PR TITLE
fix url to grafana dashboard in github

### DIFF
--- a/docs/projects/speedtest-exporter.md
+++ b/docs/projects/speedtest-exporter.md
@@ -184,7 +184,7 @@ You can check the changelog [here][7]
 [3]: https://www.speedtest.net/apps/cli
 [4]: https://c.speedtest.net/speedtest-servers-static.php
 [5]: https://grafana.com/grafana/dashboards/13665
-[6]: https://github.com/MiguelNdeCarvalho/speedtest-exporter/blob/main/Dashboard/Speedtest%20Dashboard-1609529464845.json
+[6]: https://github.com/MiguelNdeCarvalho/speedtest-exporter/blob/main/Dashboard/Speedtest-Exporter.json
 [7]: https://github.com/MiguelNdeCarvalho/speedtest-exporter/releases
 [8]: https://github.com/users/miguelndecarvalho/packages/container/package/speedtest-exporter
 [9]: https://hub.docker.com/repository/docker/miguelndecarvalho/speedtest-exporter


### PR DESCRIPTION
PS: I write an helm-chart [here](https://codeberg.org/wrenix/helm-charts/src/branch/main/speedtest-exporter), but it looks like that often i do not get an Error on the tests